### PR TITLE
Updated to include dockerhub daemon image

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.1] - 2019-11-27
+### Daemon docker hub image
+- The `docker-compose.yml` file now uses the [New Relic daemon docker hub image](https://hub.docker.com/r/newrelic/c-daemon). This greatly simplifies the daemon container setup. The daemon `Dockerfile` still exists, but is only used as reference until the `docker-compose.yml` is edited to use it. 
+- The README was updated to include directions on how to use the daemon image or create your own daemon container. 
+
 ## [0.0.1] - 2019-10-24
 ### Initial public release
 - New Relic C-SDK container example.

--- a/README.md
+++ b/README.md
@@ -20,12 +20,12 @@ The application uses the following environment variables.
 Run the application by using the `run_app` script:
 * `./run_app`
 
-### Instrumented Application Container Configuration
+## Instrumented Application Container
 The app `Dockerfile` below shows how to configure an application container:
 * All the required packages to build and run are installed. See [C-SDK Requirements](https://github.com/newrelic/c-sdk#requirements) for more information. 
 * [C-SDK](https://github.com/newrelic/c-sdk) is cloned into the container.
 * The files in the `app/example` directory are copied into the container `example` directory.
-* The `C-SDK` and `example` are both built. 
+* The `C-SDK` and `example` are both compiled. 
 * Dockerize is used to overcome possible synchronization issues. If the app container is ready first, it will wait for the daemon container to be available on the daemon address.
 * Run using `./ex_container.out`.
 
@@ -67,10 +67,18 @@ CMD dockerize -wait tcp://${NEW_RELIC_DAEMON_ADDRESS} \
   && ./ex_container.out
 ```
 
-### Daemon Container Configuration
-The daemon `Dockerfile` below shows how to configure a daemon container:
+## Daemon Container
+There are two ways to configure the daemon container:
+* Pre-made `newrelic/c-daemon` Docker image.
+* Create your own daemon container.
+
+### Daemon Docker Image
+To simplify the daemon container configuration, New Relic has published a `newrelic/c-daemon` docker image. To use it, pull the image with the `docker pull newrelic/c-daemon` command and run it with the `docker run --name [daemon-name] newrelic-daemon`. The daemon in this image listens on port `31339`. For more information on this image, visit [Docker Hub](https://hub.docker.com/r/newrelic/c-daemon) or our [repo](https://github.com/newrelic/newrelic-c-daemon-docker).
+
+### Daemon `Dockerfile`
+If you want to manually set up the daemon container, the `Dockerfile` below demonstrates how this would be accomplished: 
 * All the required packages to build and run are installed. See [C-SDK Requirements](https://github.com/newrelic/c-sdk#requirements) for more information. 
-* [C-SDK](https://github.com/newrelic/c-sdk#requirements) is cloned into the container.
+* [C-SDK](https://github.com/newrelic/c-sdk) is cloned into the container.
 * The `daemon` is compiled and started.
 * Run using the `--address` and `--watchdog-foreground` 
     - `--address` argument is used to set a port the daemon is accepting connections on. `--address` and `NEW_RELIC_DAEMON_ADDRESS` (environment variable in the app section of the `docker_compose.yml`) must match.
@@ -95,12 +103,37 @@ RUN make daemon
 
 # Run daemon
 CMD ./newrelic-daemon --logfile stdout --loglevel debug --address=daemon:31339  --watchdog-foreground
-
 ```
 
-### Application Docker Compose
-The `docker_compose.yml` file below displays the container structure of the example application. Environment variables used in `app/Dockerfile` are set here (using a valid `NEW_RELIC_LICENSE_KEY`, `NEW_RELIC_APP_NAME` and `NEW_RELIC_HOST` ). The port the daemon is listening on `expose` is set here. This must match the `--address` (daemon startup argument) and `NEW_RELIC_DAEMON_ADDRESS` (in the app `environement` section).
+## Application Docker Compose
+The `docker_compose.yml` file displays the container structure of the example application. It will look differently depending on how you configure the daemon container. Using the `newrelic/c-daemon` image simplifies daemon container setup, but limits the ability to use the non-default port. If you would like to use a different port for the agent <--> daemon connection, manual daemon container setup is recommended.
 
+### App
+The app section is used to setup the app container. Environment variables used in `app/Dockerfile` are set here (using a valid `NEW_RELIC_LICENSE_KEY`, `NEW_RELIC_APP_NAME` and `NEW_RELIC_HOST` ).
+
+### Daemon
+#### Daemon Docker Image
+When using the pre-made [`newrelic/c-daemon`](https://hub.docker.com/r/newrelic/c-daemon) image, `image: newrelic/c-daemon` is added to the daemon section. The default port for this image is `31339` and cannot be changed.
+``` 
+version: '2.4'
+
+services:
+  app:
+    build:
+      context: app 
+    depends_on:
+      - "daemon"
+    environment:
+      NEW_RELIC_LICENSE_KEY: ${NEW_RELIC_LICENSE_KEY}
+      NEW_RELIC_APP_NAME: ${NEW_RELIC_APP_NAME}
+      NEW_RELIC_HOST: ${NEW_RELIC_HOST}
+      NEW_RELIC_DAEMON_ADDRESS: "daemon:31339"
+  daemon:
+    image: newrelic/c-daemon
+```
+
+#### Create Your Own Daemon Container
+When manually setting up the daemon (downloading and installing the daemon in its container), `expose` is used to set the port the daemon is listening on. This must match the `--address` (daemon startup argument) and `NEW_RELIC_DAEMON_ADDRESS` (in the app `environement` section).
 ```
 version: '2.4'
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,7 +17,4 @@ services:
       NEW_RELIC_HOST: ${NEW_RELIC_HOST}
       NEW_RELIC_DAEMON_ADDRESS: "daemon:31339"
   daemon:
-    build:
-      context: daemon
-    expose:
-      - "31339"
+    image: newrelic/c-daemon

--- a/run_app
+++ b/run_app
@@ -1,4 +1,4 @@
 #!/bin/sh
 
-# Actually run the application.
+# Run the application.
 docker-compose up --build


### PR DESCRIPTION
The example app now uses the `newrelic/c-daemon` docker image. The README is also updated with directions on how to use the daemon image or create your own daemon container.